### PR TITLE
Add CPT Descriptions Table

### DIFF
--- a/databases/cpt_descriptions.sql
+++ b/databases/cpt_descriptions.sql
@@ -1,9 +1,10 @@
-create table cpt_descriptions as with short_desc as (
+create table cpt_descriptions as 
+with short_desc as (
 select
 code, 
 str as short_desc
 from mrconso
-where SAB = 'CPT' and tty='AB'),
+where SAB = 'CPT' and tty='AB' ),
 consumer_desc as (
 select
 code, 

--- a/databases/cpt_descriptions.sql
+++ b/databases/cpt_descriptions.sql
@@ -1,4 +1,4 @@
-with short_desc as (
+create table cpt_descriptions as with short_desc as (
 select
 code, 
 str as short_desc
@@ -21,24 +21,28 @@ where SAB = 'CPT' and tty='ETCLIN'
 medium_descriptor as (
 select
 code, 
-str as medium_descriptor
+str as medium_desc
 from mrconso
 where SAB = 'CPT' and tty='SY'),
 full_descriptor as (
 select
 code, 
-str as full_description
+str as full_desc
 from mrconso
 where SAB = 'CPT' and tty='PT'
 )
 
 SELECT 
-sd.code
+sd.code,
+short_desc,
+consumer_desc,
+clinician_desc,
+medium_desc,
+full_desc
 
 from short_desc sd
     join consumer_desc cd on sd.code = cd.code
     join clinician_desc cl_d on sd.code = cl_d.code
     join medium_descriptor md on sd.code = md.code
     join full_descriptor fd on sd.code = fd.code
-
-where sd.code = '99212'
+;

--- a/databases/cpt_descriptions.sql
+++ b/databases/cpt_descriptions.sql
@@ -1,0 +1,44 @@
+with short_desc as (
+select
+code, 
+str as short_desc
+from mrconso
+where SAB = 'CPT' and tty='AB'),
+consumer_desc as (
+select
+code, 
+str as consumer_desc
+from mrconso
+where SAB = 'CPT' and tty='ETCF'
+),
+clinician_desc as (
+select
+code, 
+str as clinician_desc
+from mrconso
+where SAB = 'CPT' and tty='ETCLIN'
+),
+medium_descriptor as (
+select
+code, 
+str as medium_descriptor
+from mrconso
+where SAB = 'CPT' and tty='SY'),
+full_descriptor as (
+select
+code, 
+str as full_description
+from mrconso
+where SAB = 'CPT' and tty='PT'
+)
+
+SELECT 
+sd.code
+
+from short_desc sd
+    join consumer_desc cd on sd.code = cd.code
+    join clinician_desc cl_d on sd.code = cl_d.code
+    join medium_descriptor md on sd.code = md.code
+    join full_descriptor fd on sd.code = fd.code
+
+where sd.code = '99212'

--- a/databases/umls.sh
+++ b/databases/umls.sh
@@ -109,6 +109,8 @@ if [ ! -e umls.db ]; then
 	sqlite3 umls.db "ALTER TABLE descriptions ADD COLUMN STY TEXT"
 	sqlite3 umls.db "CREATE INDEX X_CUI_desc ON descriptions (CUI)"
 	sqlite3 umls.db "UPDATE descriptions SET STY = (SELECT GROUP_CONCAT(MRSTY.TUI, '|') FROM MRSTY WHERE MRSTY.CUI = descriptions.CUI GROUP BY MRSTY.CUI)"
+	sqlite3 umls.db "CREATE INDEX sab_tty on mrconso(sab,tty)"
+	sqlite3 umls.db ".read databases/cpt_descriptions.sql"
 else
 	echo "=> umls.db already exists"
 fi

--- a/databases/umls.sh
+++ b/databases/umls.sh
@@ -35,7 +35,7 @@ if [ ! -e umls.db ]; then
 		current=$(pwd)
 		cd "$1/META"
 		echo "-> Converting RRF files for SQLite"
-		for f in MRCONSO.RRF MRDEF.RRF MRSTY.RRF MRREL.RRF; do
+		for f in MRCONSO.RRF MRDEF.RRF MRSTY.RRF; do
 			sed -e 's/.$//' -e 's/"//g' "$f" > "${f%RRF}pipe"
 		done
 		cd $current
@@ -85,26 +85,7 @@ if [ ! -e umls.db ]; then
 		ATUI varchar,
 		CVF varchar
 	)"
-	# init the database for MRREL
-	sqlite3 umls.db "CREATE TABLE MRREL (
-		CUI1 varchar,
-		AUI1 varchar,
-		STYPE1 varchar,
-		REL varchar,
-		CUI2 varchar,
-		AUI2 varchar,
-		STYPE2, 
-		RELA,
-		RUI,
-		SRUI,
-		SAB,
-		SL,
-		DIR,
-		RG,
-		SUPRESS,
-		CVF
-		)
-"	
+	
 	# import tables
 	for f in "$1/META/"*.pipe; do
 		table=$(basename ${f%.pipe})

--- a/databases/umls.sh
+++ b/databases/umls.sh
@@ -35,7 +35,7 @@ if [ ! -e umls.db ]; then
 		current=$(pwd)
 		cd "$1/META"
 		echo "-> Converting RRF files for SQLite"
-		for f in MRCONSO.RRF MRDEF.RRF MRSTY.RRF; do
+		for f in MRCONSO.RRF MRDEF.RRF MRSTY.RRF MRREL.RRF; do
 			sed -e 's/.$//' -e 's/"//g' "$f" > "${f%RRF}pipe"
 		done
 		cd $current
@@ -85,7 +85,26 @@ if [ ! -e umls.db ]; then
 		ATUI varchar,
 		CVF varchar
 	)"
-	
+	# init the database for MRREL
+	sqlite3 umls.db "CREATE TABLE MRREL (
+		CUI1 varchar,
+		AUI1 varchar,
+		STYPE1 varchar,
+		REL varchar,
+		CUI2 varchar,
+		AUI2 varchar,
+		STYPE2, 
+		RELA,
+		RUI,
+		SRUI,
+		SAB,
+		SL,
+		DIR,
+		RG,
+		SUPRESS,
+		CVF
+		)
+"	
 	# import tables
 	for f in "$1/META/"*.pipe; do
 		table=$(basename ${f%.pipe})

--- a/rxnorm.py
+++ b/rxnorm.py
@@ -14,6 +14,7 @@ import xml.etree.ElementTree as ET
 from collections import Counter, OrderedDict
 from sqlite import SQLite
 from graphable import GraphableObject, GraphableRelation
+import os
 
 
 class RxNorm (object):
@@ -107,7 +108,9 @@ class RxNormLookup (object):
 	
 	def __init__(self):
 		absolute = os.path.dirname(os.path.realpath(__file__))
-		self.sqlite = SQLite.get(os.path.join(absolute, 'databases/rxnorm.db'))
+		db_file = os.environ.get('SQLITE_FILE')
+		db_file = db_file if db_file else os.path.join(absolute, 'databases/rxnorm.db')
+		self.sqlite = SQLite.get(db_file)
 	
 	
 	# MARK: - "name" lookup

--- a/rxnorm.py
+++ b/rxnorm.py
@@ -14,7 +14,6 @@ import xml.etree.ElementTree as ET
 from collections import Counter, OrderedDict
 from sqlite import SQLite
 from graphable import GraphableObject, GraphableRelation
-import os
 
 
 class RxNorm (object):
@@ -108,9 +107,7 @@ class RxNormLookup (object):
 	
 	def __init__(self):
 		absolute = os.path.dirname(os.path.realpath(__file__))
-		db_file = os.environ.get('SQLITE_FILE')
-		db_file = db_file if db_file else os.path.join(absolute, 'databases/rxnorm.db')
-		self.sqlite = SQLite.get(db_file)
+		self.sqlite = SQLite.get(os.path.join(absolute, 'databases/rxnorm.db'))
 	
 	
 	# MARK: - "name" lookup


### PR DESCRIPTION
## Adding a CPT View to UMLS Flow
CPT codes are everywhere in a lot of healthcare datasets. A little while ago, they were added to UMLS giving a range of descriptions of for those codes that are very helpful. 

I followed the approach that is used in the RXNORM database to create a table that contained the cpt descriptions in all its forms. 

The resultant table takes the following form:

|Column|Description|
|-------|------------|
|code|The CPT Code
|short_desc| AMA Supplied short description based on `AB`
|consumer_desc| AMA description for printing on consumer facing applications based on `ETCF`
|clinician_desc| Clinician description based on `ETCLIN`
|medium_desc| based on `SY`
|full_desc| based on `PT`

the documentation on the CPT source that defines these terms is at [Metathesaurus Representation](https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/CPT/metarepresentation.html)